### PR TITLE
Build: add missing link libraries for building on Windows

### DIFF
--- a/compressible/Make/options
+++ b/compressible/Make/options
@@ -12,6 +12,7 @@ EXE_INC = \
 
 LIB_LIBS = \
     -lcompressibleTransportModels \
+    -lcompressibleTurbulenceModels \
     -lfluidThermophysicalModels \
     -lsolidThermo \
     -lsolidSpecie \

--- a/incompressible/Make/options
+++ b/incompressible/Make/options
@@ -9,6 +9,7 @@ EXE_INC = \
 
 LIB_LIBS = \
     -lincompressibleTransportModels \
+    -lincompressibleTurbulenceModels \
     -lturbulenceModels \
     -lfiniteVolume \
     -lmeshTools


### PR DESCRIPTION
Added missing libraries for linking on Windows.
The build did not fail on Linux because the Linux linker allows symbols to remain undefined, while Windows forces all symbols to be defined when building a shared library.